### PR TITLE
Aardwolf doesn't share any code with DIKU

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ damp
 daagar's aardwolf and mudlet package
 
 
-A small set of scripts for the Mudlet mud client, and the DIKU Mud "Aardwolf". Primary focus is on a passable set
+A small set of scripts for the Mudlet mud client, and the Mud "Aardwolf". Primary focus is on a passable set
 of scripts to support mapping, though a very basic GUI for health/mana/etc., bars is now included.
 
 Please see the [wiki][] for details.


### PR DESCRIPTION
It was once based on DIKU, many many years ago, but hasn't been for a 
rather long time now. see 'help diku' in game.